### PR TITLE
Remove CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,0 @@
-* @reinzor


### PR DESCRIPTION
@Rayman Nice idea, but if @reinzor is code owner, he must be the one to review, but organization policy disables him from reviewing his own PR, so that locks his PR.