### PR TITLE
Add a missing symbolic link

### DIFF
--- a/openpose_ros/README.md
+++ b/openpose_ros/README.md
@@ -19,6 +19,7 @@ sudo ln -fs /opt/ros/kinetic/lib/libopencv_highgui3.so /usr/lib/libopencv_highgu
 sudo ln -fs /opt/ros/kinetic/lib/libopencv_imgcodecs3.so /usr/lib/libopencv_imgcodecs.so
 sudo ln -fs /opt/ros/kinetic/lib/libopencv_imgproc3.so /usr/lib/libopencv_imgproc.so
 sudo ln -fs /opt/ros/kinetic/lib/libopencv_videoio3.so /usr/lib/libopencv_videoio.so
+sudo ln -fs /opt/ros/kinetic/lib/libopencv_objdetect3.so /usr/lib/libopencv_objdetect.so
 sudo ln -fs /opt/ros/kinetic/include/opencv-3.2.0-dev/opencv2 /usr/include/opencv2
 ```
 


### PR DESCRIPTION
There seems to be missing a symbolic link inside the readme for openpose. 

I has unable to compile openpose because of a missing link to libopencv_objdetect.

The error I has getting was ```cannot find -lopencv_objdetect```.

I solved it by adding a symlink to the library ```sudo ln -fs /opt/ros/kinetic/lib/libopencv_objdetect3.so /usr/lib/libopencv_objdetect.so```