### PR TITLE
use new tf API

### DIFF
--- a/tensorflow_ros/src/tensorflow_ros/tf_retrain.py
+++ b/tensorflow_ros/src/tensorflow_ros/tf_retrain.py
@@ -688,10 +688,10 @@ def add_input_distortions(flip_left_right, random_crop, random_scale,
   resize_scale_value = tf.random_uniform(tensor_shape.scalar(),
                                          minval=1.0,
                                          maxval=resize_scale)
-  scale_value = tf.mul(margin_scale_value, resize_scale_value)
-  precrop_width = tf.mul(scale_value, MODEL_INPUT_WIDTH)
-  precrop_height = tf.mul(scale_value, MODEL_INPUT_HEIGHT)
-  precrop_shape = tf.pack([precrop_height, precrop_width])
+  scale_value = tf.multiply(margin_scale_value, resize_scale_value)
+  precrop_width = tf.multiply(scale_value, MODEL_INPUT_WIDTH)
+  precrop_height = tf.multiply(scale_value, MODEL_INPUT_HEIGHT)
+  precrop_shape = tf.stack([precrop_height, precrop_width])
   precrop_shape_as_int = tf.cast(precrop_shape, dtype=tf.int32)
   precropped_image = tf.image.resize_bilinear(decoded_image_4d,
                                               precrop_shape_as_int)
@@ -708,7 +708,7 @@ def add_input_distortions(flip_left_right, random_crop, random_scale,
   brightness_value = tf.random_uniform(tensor_shape.scalar(),
                                        minval=brightness_min,
                                        maxval=brightness_max)
-  brightened_image = tf.mul(flipped_image, brightness_value)
+  brightened_image = tf.multiply(flipped_image, brightness_value)
   distort_result = tf.expand_dims(brightened_image, 0, name='DistortResult')
   return jpeg_data, distort_result
 


### PR DESCRIPTION
The tf.stack instead of tf.pack, I retrieved from the new tf_retrain.

If you set flipped images to true and try to train, you will get the error:
```
ile "/home/amigo/ros/kinetic/system/src/tensorflow_ros/src/tensorflow_ros/tf_retrain.py", line 691, in add_input_distortions
    scale_value = tf.mul(margin_scale_value, resize_scale_value)
AttributeError: 'module' object has no attribute 'mul'
```
This will be solved by this PR.