### PR TITLE
Fix underscore replacement in output_labels.txt

### DIFF
--- a/tensorflow_ros/src/tensorflow_ros/tf_retrain.py
+++ b/tensorflow_ros/src/tensorflow_ros/tf_retrain.py
@@ -260,7 +260,7 @@ def create_image_lists(image_dir, testing_percentage, validation_percentage):
       tf.logging.warning(
           'WARNING: Folder {} has more than {} images. Some images will '
           'never be selected.'.format(dir_name, MAX_NUM_IMAGES_PER_CLASS))
-    label_name = re.sub(r'[^a-z0-9]+', ' ', dir_name.lower())
+    label_name = re.sub(r'[^a-z0-9_]+', ' ', dir_name.lower())
     training_images = []
     testing_images = []
     validation_images = []


### PR DESCRIPTION
Fix for #66 
Underscores now stay in the name of the labels and don't get replaced by spaces anymore. 