### PR TITLE
Industrial-CI: upgrade pip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ dist: xenial
 matrix:
   include:
   - name: "Kinetic"
-    env: BEFORE_SCRIPT="pip install pip --upgrade" ROS_DISTRO=kinetic
+    env: BEFORE_SCRIPT="pip install pip setuptools --upgrade && hash -r" ROS_DISTRO=kinetic
 
 install:
   - git clone https://github.com/ros-industrial/industrial_ci.git .ci_config

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 sudo: required
 language: generic
-dist: trusty
+dist: xenial
 
 matrix:
   include:
   - name: "Kinetic"
-    env: ROS_DISTRO=kinetic
+    env: BEFORE_SCRIPT="pip install pip --upgrade" ROS_DISTRO=kinetic
 
 install:
   - git clone https://github.com/ros-industrial/industrial_ci.git .ci_config


### PR DESCRIPTION
use BEFORE_SCRIPT to upgrade pip.

As suggested in https://github.com/ros-industrial/industrial_ci/issues/405

fixes https://github.com/ros/rosdistro/issues/22075
fixes #96