### PR TITLE
fix(CMake): find package jetson-utils

### DIFF
--- a/image_recognition_jetson/CMakeLists.txt
+++ b/image_recognition_jetson/CMakeLists.txt
@@ -22,6 +22,7 @@ catkin_package(
 
 include_directories(${catkin_INCLUDE_DIRS})
 
+find_package(jetson-utils)
 find_package(jetson-inference)
 if(jetson-inference_FOUND) # If we are on Jetson, use the actual impl, otherwise a mock
     find_package(CUDA REQUIRED)


### PR DESCRIPTION
In a newer version of jetson-inference and jetson-utils, you will need this line in order for CMake to find jetson-utils, and CMake needs to find jetson-utils to find jetson-inference.

Fixes #100