### PR TITLE
(travis) keras<2.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: generic
 
 env:
   global:
-    - BEFORE_INIT="apt-get install -y -q python-pip && pip install --upgrade pip && hash -r pip && pip install --upgrade enum34 pyasn1-modules 'tensorflow>=2.1' --progress-bar=off"
+    - BEFORE_INIT="apt-get install -y -q python-pip && pip install --upgrade pip && hash -r pip && pip install --upgrade enum34 pyasn1-modules 'tensorflow>=2.1' 'keras<2.4' --progress-bar=off"
 
 jobs:
   include:


### PR DESCRIPTION
As keras 2.4 requires tensorflow 2.2, but that doesn't support python2.